### PR TITLE
chore(renovate): enable automerge for cargo crates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,22 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "description": "automerge Rust crate updates (>= 1.0.0)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["cargo"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "description": "automerge Rust crate updates (< 1.0.0)",
+      "matchUpdateTypes": ["patch"],
+      "matchManagers": ["cargo"],
+      "matchCurrentVersion": "/^0/",
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## やったこと
CargoクレートのSemVerにおける破壊的変更がないバージョンの更新に限り自動でマージするようにした

## 背景
* DockerのビルドがPRで走りキャッシュされていないので重い
  * renovateはmaster/HEADに常にrebaseし、そのたびにDockerのビルドが走る
* notificationがうるさい
* SemVerの破壊的変更があるバージョンを避ければautomergeしてもよいはず
  * もしライブラリの作者によって規約が破られたとしてもコンパイルエラーになったりテストが落ちたりするので気がつくはず

## やること
renovate-approveのインストール
* このレポジトリはマージするためにapproveが必要
* renovate-approveが動作するためにはauto mergeが有効化されている必要がある
  * `.github/workflows/ci.yaml`にテストとコンテナのビルドの両方が成功したときにauto mergeを有効にできれば良い
